### PR TITLE
[EuiDataGrid] Adjust footer row styles and make it sticky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added build-specific babel configurations for docs and tests ([#3911](https://github.com/elastic/eui/pull/3911))
 - Updated browserslist configuration to remove IE accommodations ([#3911](https://github.com/elastic/eui/pull/3911))
 - Removed docgenInfo from non-docs production builds ([#3911](https://github.com/elastic/eui/pull/3911))
+- Added footer row to `EuiDataGrid` via the `renderFooterCellValue` prop ([#3770](https://github.com/elastic/eui/pull/3770))
 
 **Bug fixes**
 

--- a/src-docs/src/views/datagrid/footer_row.js
+++ b/src-docs/src/views/datagrid/footer_row.js
@@ -135,7 +135,6 @@ export default () => {
             border: 'horizontal',
             rowHover: 'highlight',
             header: 'underline',
-            footer: 'overline',
           }}
         />
       </EuiFlexItem>

--- a/src-docs/src/views/datagrid/styling.js
+++ b/src-docs/src/views/datagrid/styling.js
@@ -11,6 +11,7 @@ import {
   EuiAvatar,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiCallOut,
 } from '../../../../src/components/';
 
 const columns = [
@@ -36,7 +37,7 @@ const columns = [
 
 const data = [];
 
-for (let i = 1; i < 5; i++) {
+for (let i = 1; i < 6; i++) {
   data.push({
     avatar: (
       <EuiAvatar
@@ -54,7 +55,7 @@ for (let i = 1; i < 5; i++) {
 }
 
 const footerCellValues = {
-  avatar: '4 accounts',
+  avatar: '5 accounts',
 };
 
 const renderFooterCellValue = ({ columnId }) =>
@@ -149,6 +150,10 @@ export default class DataGrid extends Component {
       {
         id: 'overline',
         label: 'Overline',
+      },
+      {
+        id: 'striped',
+        label: 'Striped',
       },
     ];
 
@@ -454,7 +459,7 @@ export default class DataGrid extends Component {
               isOpen={this.state.isPopoverOpen}
               anchorPosition="rightUp"
               closePopover={this.closePopover.bind(this)}>
-              <div style={{ width: 300 }}>
+              <div style={{ width: 380 }}>
                 <EuiFormRow label="Border" display="columnCompressed">
                   <EuiButtonGroup
                     isFullWidth
@@ -654,6 +659,17 @@ export default class DataGrid extends Component {
             </EuiPopover>
           </EuiFlexItem>
         </EuiFlexGroup>
+
+        {this.state.footerSelected === 'striped' ? (
+          <>
+            <EuiSpacer />
+
+            <EuiCallOut
+              size="s"
+              title="A striped footer will be shaded depending on whether it is an even or an odd row considering the rest of the rows in the datagrid. Needs to be used with stripes={true}."
+            />
+          </>
+        ) : null}
 
         <EuiSpacer />
 

--- a/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
+++ b/src/components/datagrid/__snapshots__/data_grid.test.tsx.snap
@@ -181,7 +181,7 @@ Array [
     data-focus-lock-disabled="disabled"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight testClass1 testClass2"
+      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter testClass1 testClass2"
     >
       <div
         class="euiDataGrid__controls"
@@ -719,7 +719,7 @@ Array [
     data-focus-lock-disabled="disabled"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight testClass1 testClass2"
+      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter testClass1 testClass2"
     >
       <div
         class="euiDataGrid__controls"
@@ -1581,7 +1581,7 @@ Array [
     data-focus-lock-disabled="disabled"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight testClass1 testClass2"
+      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter testClass1 testClass2"
     >
       <div
         class="euiDataGrid__controls"
@@ -2118,7 +2118,7 @@ Array [
     data-focus-lock-disabled="disabled"
   >
     <div
-      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight testClass1 testClass2"
+      class="euiDataGrid euiDataGrid--bordersAll euiDataGrid--headerShade euiDataGrid--footerOverline euiDataGrid--rowHoverHighlight euiDataGrid--stickyFooter testClass1 testClass2"
     >
       <div
         class="euiDataGrid__controls"

--- a/src/components/datagrid/_data_grid.scss
+++ b/src/components/datagrid/_data_grid.scss
@@ -97,7 +97,7 @@
 .euiDataGrid__overflow {
   overflow-y: hidden;
   height: 100%;
-  background: $euiPageBackgroundColor;
+  background: $euiColorEmptyShade;
 }
 
 // This is used to remove extra scrollbars on the body when fullscreen is enabled

--- a/src/components/datagrid/_data_grid_footer_row.scss
+++ b/src/components/datagrid/_data_grid_footer_row.scss
@@ -12,7 +12,7 @@
     border-top: $euiBorderThick;
     // sass-lint:disable-block no-important
     border-top-color: $euiTextColor !important;
-    background: none !important;
+    background: $euiColorEmptyShade !important;
   }
 }
 

--- a/src/components/datagrid/_data_grid_footer_row.scss
+++ b/src/components/datagrid/_data_grid_footer_row.scss
@@ -2,9 +2,11 @@
   font-weight: $euiFontWeightBold;
 }
 
-.euiDataGridFooter {
-  position: sticky;
-  bottom: 0;
+@include euiDataGridStyles(stickyFooter) {
+  .euiDataGridFooter {
+    position: sticky;
+    bottom: 0;
+  }
 }
 
 @include euiDataGridStyles(footerOverline) {

--- a/src/components/datagrid/_data_grid_footer_row.scss
+++ b/src/components/datagrid/_data_grid_footer_row.scss
@@ -2,11 +2,17 @@
   font-weight: $euiFontWeightBold;
 }
 
+.euiDataGridFooter {
+  position: sticky;
+  bottom: 0;
+}
+
 @include euiDataGridStyles(footerOverline) {
   @include euiDataGridFooterCell {
     border-top: $euiBorderThick;
     // sass-lint:disable-block no-important
     border-top-color: $euiTextColor !important;
+    background: none !important;
   }
 }
 

--- a/src/components/datagrid/_data_grid_header_row.scss
+++ b/src/components/datagrid/_data_grid_header_row.scss
@@ -2,7 +2,7 @@
   display: inline-flex;
   min-width: 100%; // Needed to prevent wraps. Inline flex is tricky
   z-index: 3; // Needs to sit above the content and focused cells
-  background: $euiColorLightestShade;
+  background: $euiColorEmptyShade;
   position: sticky; // In IE11 this does not work, but doesn't cause a break.
   top: 0;
 }

--- a/src/components/datagrid/_mixins.scss
+++ b/src/components/datagrid/_mixins.scss
@@ -18,6 +18,7 @@ $euiDataGridStyles: (
   'fontSizeSmall'
   'fontSizeLarge'
   'noControls'
+  'stickyFooter'
 );
 
 // All this does is take some of the above and make a sibling selector

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -811,6 +811,9 @@ export const EuiDataGrid: FunctionComponent<EuiDataGridProps> = props => {
       'euiDataGrid--stripes': gridStyles.stripes!,
     },
     {
+      'euiDataGrid--stickyFooter': gridStyles.footer && gridStyles.stickyFooter,
+    },
+    {
       'euiDataGrid--fullScreen': isFullScreen,
     },
     {

--- a/src/components/datagrid/data_grid.tsx
+++ b/src/components/datagrid/data_grid.tsx
@@ -177,6 +177,7 @@ const headerToClassMap: { [header in EuiDataGridStyleHeader]: string } = {
 const footerToClassMap: { [footer in EuiDataGridStyleFooter]: string } = {
   shade: 'euiDataGrid--footerShade',
   overline: 'euiDataGrid--footerOverline',
+  striped: '',
 };
 
 const rowHoverToClassMap: {

--- a/src/components/datagrid/data_grid_footer_row.tsx
+++ b/src/components/datagrid/data_grid_footer_row.tsx
@@ -72,7 +72,11 @@ const EuiDataGridFooterRow: FunctionComponent<EuiDataGridFooterRowProps> = memo(
     visibleRowIndex = rowIndex,
     ...rest
   }) => {
-    const classes = classnames('euiDataGridRow', className);
+    const classes = classnames(
+      'euiDataGridRow',
+      'euiDataGridFooter',
+      className
+    );
     const dataTestSubj = classnames('dataGridRow', _dataTestSubj);
 
     return (

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -96,7 +96,7 @@ export interface EuiDataGridColumnWidths {
 export type EuiDataGridStyleFontSizes = 's' | 'm' | 'l';
 export type EuiDataGridStyleBorders = 'all' | 'horizontal' | 'none';
 export type EuiDataGridStyleHeader = 'shade' | 'underline';
-export type EuiDataGridStyleFooter = 'shade' | 'overline';
+export type EuiDataGridStyleFooter = 'shade' | 'overline' | 'striped';
 export type EuiDataGridStyleRowHover = 'highlight' | 'none';
 export type EuiDataGridStyleCellPaddings = 's' | 'm' | 'l';
 

--- a/src/components/datagrid/data_grid_types.ts
+++ b/src/components/datagrid/data_grid_types.ts
@@ -129,6 +129,10 @@ export interface EuiDataGridStyle {
    * Defines the padding with the row and column cells
    */
   cellPadding?: EuiDataGridStyleCellPaddings;
+  /**
+   * If set to true, the footer row will be sticky
+   */
+  stickyFooter?: boolean;
 }
 
 export interface EuiDataGridToolBarVisibilityColumnSelectorOptions {

--- a/src/components/datagrid/style_selector.tsx
+++ b/src/components/datagrid/style_selector.tsx
@@ -31,6 +31,7 @@ export const startingStyles: EuiDataGridStyle = {
   rowHover: 'highlight',
   header: 'shade',
   footer: 'overline',
+  stickyFooter: true,
 };
 
 const densityStyles: { [key: string]: Partial<EuiDataGridStyle> } = {


### PR DESCRIPTION
### Summary

The behaviour I'm proposing for the styling of the footer row is as follows:

a) striped: it's shaded following the odd/even styling of the rest of the datagrid. Needs to be used with `stripes={true}`.
b) overline: gets a thick black line above.
c) shaded: always gets a gray background.

![modes_e](https://user-images.githubusercontent.com/4016496/91793447-0ef54700-ebcd-11ea-80e1-793baeefb784.gif)


I also made the footer sticky. See below:
![aaaa](https://user-images.githubusercontent.com/4016496/91793145-33045880-ebcc-11ea-8a56-9b44265306f8.gif)


### Checklist

- [ ] This was checked in mobile
- [ ] This was checked in dark mode
- [ ] Any props added have proper autodocs
- [ ] Documentation examples were added
- [ ] A [changelog](https://github.com/elastic/eui/blob/master/CHANGELOG.md) entry exists and is marked appropriately
- [ ] This was checked for breaking changes and labeled appropriately
- [ ] Jest tests were updated or added to match the most common scenarios
- [ ] This was checked against keyboard-only and screenreader scenarios

